### PR TITLE
Fix grouping error on show page

### DIFF
--- a/app/models/errdo/error.rb
+++ b/app/models/errdo/error.rb
@@ -49,7 +49,7 @@ module Errdo
     end
 
     def affected_users
-      error_occurrences.group("experiencer_id, experiencer_type").map(&:experiencer).compact
+      error_occurrences.group(:experiencer_id, :experiencer_type).select(:experiencer_id, :experiencer_type).map(&:experiencer).compact
     end
 
     def oldest_occurrence


### PR DESCRIPTION
Fix this:
```
PG::GroupingError: ERROR:  column "error_occurrences.id" must appear in the GROUP BY clause or be used in an aggregate function
LINE 1: SELECT "error_occurrences".* FROM "error_occurrences"  WHERE...
              ^
: SELECT "error_occurrences".* FROM "error_occurrences"  WHERE "error_occurrences"."error_id" = $1 GROUP BY experiencer_id, experiencer_type
```
on error show page